### PR TITLE
Not is allowed to be used for array argumenst

### DIFF
--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -212,7 +212,10 @@ struct Not: Expression {
 
     func evalWithData(_ data: JSON?) throws -> JSON {
         let lhsBool = try lhs.evalWithData(data)
-
+        if let array = lhsBool.array
+        {
+            return JSON.Bool(!array[0].truthy())
+        }
         return JSON.Bool(!lhsBool.truthy())
     }
 }


### PR DESCRIPTION
According to the [JsonLogic specification](https://jsonlogic.com/operations.html), it is allowed to have `not` operate on an array. Doing so results in inverting the truthy value of the first element of the array.