### PR TITLE
Improve handling of iso8601 Datetime strings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "jsonlogic",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v10_13), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         .library(

--- a/Sources/JSON/Date.swift
+++ b/Sources/JSON/Date.swift
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 Patrick Amrein <amrein@ubique.ch>
+// 
+// Licensed under LGPL
+
+
+import Foundation
+
+extension Date {
+    static func fromISO8601(_ dateString: String) -> Date? {
+        // `ISO8601DateFormatter` does not support fractional zeros if not
+        // configured (`.withFractionalSeconds`) and if configured, does not
+        // parse dates without fractional seconds.
+
+        let formatter = ISO8601DateFormatter()
+
+        // Try to parse without fractional seconds
+        if let d = formatter.date(from: dateString) {
+            return d
+        }
+
+        // Retry with fraction
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = formatter.date(from: dateString) {
+            return d
+        }
+
+        // nothing worked, try adding UTC timezone
+
+        let formatter_without_timezone = ISO8601DateFormatter()
+        // Try to parse without fractional seconds
+        if let d = formatter_without_timezone.date(from: dateString + "Z") {
+            return d
+        }
+
+        formatter_without_timezone.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = formatter_without_timezone.date(from: dateString + "Z") {
+            return d
+        }
+        return nil
+    }
+}

--- a/Sources/JSON/JSON.swift
+++ b/Sources/JSON/JSON.swift
@@ -600,7 +600,7 @@ extension String {
         if let date = Date.shortFormatter.date(from:self) {
             return date
         }
-        if let date = Date.fullFormatter.date(from:self) {
+        if let date = Date.fromISO8601(self) {
             return date
         }
         return nil


### PR DESCRIPTION
We use a more robust ISO8601 DateTime parser, than was used before, since the standard allows for almost any string, which represents a date.

We use the Apple `ISO8601DateFormatter` as a base, which was only available since MacOSX 10.13, hence we increase the version in the `Package.swift`