### PR TITLE
If the result is a boolean-like value return Truthy value

### DIFF
--- a/Sources/jsonlogic/JsonLogic.swift
+++ b/Sources/jsonlogic/JsonLogic.swift
@@ -129,6 +129,10 @@ public final class JsonLogic {
 
         switch convertedToSwiftStandardType {
         case let .some(value):
+        // if T is a boolean-like value return the truthy value of result
+            if let _ = true as? T {
+                return result.truthy() as! T
+            }
             guard let convertedResult = value as? T else {
                 print(" canNotConvertResultToType \(T.self) from \(type(of: value))")
                 throw JSONLogicError.canNotConvertResultToType(T.self)


### PR DESCRIPTION
The json logic does not necessarily produce a boolean value. But since we have the `truthy` method on every object, we can still return the `truthy` value. 