### PR TITLE
fixes truthy value of date

### DIFF
--- a/Sources/JSON/JSON.swift
+++ b/Sources/JSON/JSON.swift
@@ -514,6 +514,8 @@ extension JSON {
         switch self {
         case let .Bool(bool):
             return bool
+        case .Date:
+            return true
         case let .Int(number):
             return number != 0
         case let .Double(number):


### PR DESCRIPTION
The `truthy` value of a date is always true as it is a valid object.