### PR TITLE
UTC calendar for all calculations

### DIFF
--- a/Sources/JSON/Date.swift
+++ b/Sources/JSON/Date.swift
@@ -39,3 +39,15 @@ extension Date {
         return nil
     }
 }
+
+
+extension Calendar {
+    static var utc : Calendar {
+        guard let utc = TimeZone(identifier: "UTC") else {
+            return Calendar.current
+        }
+        var tmpCalendar = Calendar(identifier: .gregorian)
+        tmpCalendar.timeZone = utc
+        return tmpCalendar
+    }
+}

--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -630,32 +630,32 @@ struct MinusTime : Expression {
 func addTime(_ amount: Int, as unit: String, to: Date) -> JSON {
     switch unit {
     case "year":
-        guard let date = Calendar.current.date(byAdding: .year, value: Int(amount), to: to) else {
+        guard let date = Calendar.utc.date(byAdding: .year, value: Int(amount), to: to) else {
             return JSON.Null
         }
         return JSON(date)
     case "month":
-        guard let date = Calendar.current.date(byAdding: .month, value: Int(amount), to: to) else {
+        guard let date = Calendar.utc.date(byAdding: .month, value: Int(amount), to: to) else {
             return JSON.Null
         }
         return JSON(date)
     case "day":
-        guard let date = Calendar.current.date(byAdding: .day, value: Int(amount), to: to) else {
+        guard let date = Calendar.utc.date(byAdding: .day, value: Int(amount), to: to) else {
             return JSON.Null
         }
         return JSON(date)
     case "hour":
-        guard let date = Calendar.current.date(byAdding: .hour, value: Int(amount), to: to) else {
+        guard let date = Calendar.utc.date(byAdding: .hour, value: Int(amount), to: to) else {
             return JSON.Null
         }
         return JSON(date)
     case "minute":
-        guard let date = Calendar.current.date(byAdding: .minute, value: Int(amount), to: to) else {
+        guard let date = Calendar.utc.date(byAdding: .minute, value: Int(amount), to: to) else {
             return JSON.Null
         }
         return JSON(date)
     case "second":
-        guard let date = Calendar.current.date(byAdding: .second, value: Int(amount), to: to) else {
+        guard let date = Calendar.utc.date(byAdding: .second, value: Int(amount), to: to) else {
             return JSON.Null
         }
         return JSON(date)


### PR DESCRIPTION
We use a `UTC` calendar (if available) for `plusTime` operations, to avoid issues with summer/winter time. 