### PR TITLE
Reduce code duplication for easier reading

### DIFF
--- a/Sources/jsonlogic/Parser.swift
+++ b/Sources/jsonlogic/Parser.swift
@@ -818,21 +818,13 @@ class Parser {
             return Divide(arg: try self.parse(json: value))
         case "%":
             return Modulo(arg: try self.parse(json: value))
-        case ">":
+        case ">", "after":
             return Comparison(arg: try self.parse(json: value), operation: >)
-        case "after":
-            return Comparison(arg: try self.parse(json: value), operation: >)
-        case "<":
+        case "<", "before":
             return Comparison(arg: try self.parse(json: value), operation: <)
-        case "before":
-            return Comparison(arg: try self.parse(json: value), operation: <)
-        case ">=":
+        case ">=", "not-before":
             return Comparison(arg: try self.parse(json: value), operation: >=)
-        case "not-before":
-            return Comparison(arg: try self.parse(json: value), operation: >=)
-        case "<=":
-            return Comparison(arg: try self.parse(json: value), operation: <=)
-        case "not-after":
+        case "<=", "not-after":
             return Comparison(arg: try self.parse(json: value), operation: <=)
         case "if", "?:":
             guard let array = try self.parse(json: value) as? ArrayOfExpressions else {


### PR DESCRIPTION
This PR tries to reduce complexity by removing the duplicated code lines.

Although it is not the same semantic, as `after` and its variants (should be) are implicitly bound to a `DateTime` type, but since `JsonLogic` is not strictly typed, there is no difference and hence the lines are just duplicated for semantics (I guess?) reason.

By combining the two, it also helps to understand the meaning of `after`, as it is equivalent to the greater/less than operators, which possibly helps during debugging of certain rules.