### PR TITLE
Greatly improve Performance by avoiding unnecessary date parsing attempts

### DIFF
--- a/Sources/JSON/Date.swift
+++ b/Sources/JSON/Date.swift
@@ -19,8 +19,9 @@ extension Date {
 
     static func fromISO8601(_ dateString: String) -> Date? {
         // An ISO 8601 date needs to at least contain dashes
-        // If the string does not contain any dashes we can avoid the costly
-        // date parsing
+        // If the string does not have a minimum length and contain any dashes
+        // we can avoid the costly date parsing
+        guard dateString.count >= 10 else { return nil }
         guard dateString.contains("-") else { return nil }
         
         // `ISO8601DateFormatter` does not support fractional zeros if not

--- a/Sources/JSON/Date.swift
+++ b/Sources/JSON/Date.swift
@@ -18,6 +18,11 @@ extension Date {
     }()
 
     static func fromISO8601(_ dateString: String) -> Date? {
+        // An ISO 8601 date needs to at least contain dashes
+        // If the string does not contain any dashes we can avoid the costly
+        // date parsing
+        guard dateString.contains("-") else { return nil }
+        
         // `ISO8601DateFormatter` does not support fractional zeros if not
         // configured (`.withFractionalSeconds`) and if configured, does not
         // parse dates without fractional seconds.

--- a/Sources/JSON/JSON.swift
+++ b/Sources/JSON/JSON.swift
@@ -576,9 +576,10 @@ extension Date {
     static func dateFromShortFormatString(_ string: String) -> Date? {
         // Since we use a DateFormatter with a fixed format we only need
         // to attempt parsing a date when we have a string with the exact length
-        guard string.count == 10 else { return nil }
+        let trimmedString = string.trimmingCharacters(in: .whitespaces)
+        guard trimmedString.count == 10 else { return nil }
         // and additionally if the fifth character is a dash
-        guard string[string.index(string.startIndex, offsetBy: 4)] == "-" else { return nil }
+        guard trimmedString[trimmedString.index(string.startIndex, offsetBy: 4)] == "-" else { return nil }
 
         return shortFormatter.date(from: string)
     }

--- a/Sources/JSON/JSON.swift
+++ b/Sources/JSON/JSON.swift
@@ -577,6 +577,8 @@ extension Date {
         // Since we use a DateFormatter with a fixed format we only need
         // to attempt parsing a date when we have a string with the exact length
         guard string.count == 10 else { return nil }
+        // and additionally if the fifth character is a dash
+        guard string[string.index(string.startIndex, offsetBy: 4)] == "-" else { return nil }
 
         return shortFormatter.date(from: string)
     }

--- a/Sources/JSON/JSON.swift
+++ b/Sources/JSON/JSON.swift
@@ -573,6 +573,14 @@ extension JSON {
 
 extension Date {
 
+    static func dateFromShortFormatString(_ string: String) -> Date? {
+        // Since we use a DateFormatter with a fixed format we only need
+        // to attempt parsing a date when we have a string with the exact length
+        guard string.count == 10 else { return nil }
+
+        return shortFormatter.date(from: string)
+    }
+    
     static var shortFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .iso8601)
@@ -608,7 +616,7 @@ extension Date {
 
 extension String {
     var date: Date? {
-        if let date = Date.shortFormatter.date(from:self) {
+        if let date = Date.dateFromShortFormatString(self) {
             return date
         }
         if let date = Date.fromISO8601(self) {


### PR DESCRIPTION
The initializer of JSON currently attempts to parse any string it receives into a date (JSON.swift line 76). When evaluating many rules via json-logic-swift this is a huge performance hit since DateFormatter parse attempts are quite expensive/slow. This pull request greatly improves the performance by avoiding unnecessary parse attempts for strings where we know that we will not have a successful parse attempt. In one case a shortFormatter is used with a fixed format which means we can rule out any strings that do not have the correct length. The other case uses an ISO8601 Date Formatter which means we can rule out any strings that do not contain dashes (-).

In our tests this resulted in an improvement by a factor of 30 on an iPad Mini.