### PR TITLE
add self cast to any

### DIFF
--- a/Sources/JSON/JSON.swift
+++ b/Sources/JSON/JSON.swift
@@ -56,6 +56,9 @@ public enum JSON: Equatable {
     public init() {
         self = .Null
     }
+    public init(_ json: JSON) {
+        self = json
+    }
 
     public init(_ array: [JSON]) {
         self = .Array(array)
@@ -68,6 +71,8 @@ public enum JSON: Equatable {
     //swiftlint:disable syntactic_sugar
     public init(_ json: Any) {
         switch json {
+        case let js as JSON:
+            self = js
         case let array as Swift.Array<Any>:
             self = .Array(array.map({JSON($0)}))
         case let dictionary as Swift.Dictionary<String, Any>:


### PR DESCRIPTION
This PR adds the cast to JSON to the list of possible `Any` values. This allows mixing pre parsed JSON values in the initialiser with non parsed objects.